### PR TITLE
[FIX] Cross-device hard links exception

### DIFF
--- a/hooks/bl2bids
+++ b/hooks/bl2bids
@@ -2,5 +2,7 @@
 
 set -x
 
-hookdir=$(dirname $(dirname $(realpath "$0")))
-singularity exec -B $hookdir -B $(realpath `pwd`) -e docker://brainlife/dipy:1.1.1 $hookdir/bl2bids.py
+hookdir=$(dirname $(realpath "$0"))
+taskdir=$(dirname $(realpath `pwd`))
+
+singularity exec -B $hookdir -B $taskdir -e docker://brainlife/dipy:1.1.1 $hookdir/bl2bids.py

--- a/hooks/bl2bids
+++ b/hooks/bl2bids
@@ -2,5 +2,5 @@
 
 set -x
 
-hookdir=$(dirname $(realpath "$0"))
+hookdir=$(dirname $(dirname $(realpath "$0")))
 singularity exec -B $hookdir -B $(realpath `pwd`) -e docker://brainlife/dipy:1.1.1 $hookdir/bl2bids.py

--- a/hooks/utils.py
+++ b/hooks/utils.py
@@ -5,6 +5,7 @@ import pathlib
 import os
 import sys
 import re
+import errno
 import nibabel as nib
 import os.path as op
 
@@ -240,7 +241,15 @@ def link(src, dest):
                 os.symlink(recover+src, dest, True)
             else:
                 print("hard-linking (existing)", src, "to (new link)", dest)
-                os.link(src, dest)
+                try:
+                    os.link(src, dest)
+                except OSError as e:
+                    if e.errno == errno.EXDEV:
+                        print("soft-linking (existing)", src, "to (new link)", dest)
+                        os.symlink(src, dest)
+                    else:
+                        raise e
+
         else:
             print(src, "not found")
     except FileExistsError:

--- a/hooks/utils.py
+++ b/hooks/utils.py
@@ -5,7 +5,6 @@ import pathlib
 import os
 import sys
 import re
-import errno
 import nibabel as nib
 import os.path as op
 
@@ -241,15 +240,7 @@ def link(src, dest):
                 os.symlink(recover+src, dest, True)
             else:
                 print("hard-linking (existing)", src, "to (new link)", dest)
-                try:
-                    os.link(src, dest)
-                except OSError as e:
-                    if e.errno == errno.EXDEV:
-                        print("soft-linking (existing)", src, "to (new link)", dest)
-                        os.symlink(src, dest)
-                    else:
-                        raise e
-
+                os.link(src, dest)
         else:
             print(src, "not found")
     except FileExistsError:


### PR DESCRIPTION
I just had the same problem #17 with my resource.

The error happens when accessing the output of another job from the same process, in the same resource. So the command binds -B `/work/<process>/<job>` and tries to hard-link e.g. `/work/<process>/<another job>`

From what I could investigate, by binding the job directory, it considers to be in another device even if one is a subtree of another (`-B /work/<process> -B /work/<process>/<job>`):
```
/dev/mapper/ubuntu--vg-ubuntu--lv on /home/bl/abcd-spec/hooks type ext4 (rw,nosuid,nodev,relatime)
/dev/mapper/ubuntu--vg-ubuntu--lv on /home/bl/workdir/62b2095ae0370ed92af3a543 type ext4 (rw,nosuid,nodev,relatime)
/dev/mapper/ubuntu--vg-ubuntu--lv on /home/bl/workdir/62b2095ae0370ed92af3a543/62b27175e0370ed92afc9ee4 type ext4 (rw,nosuid,nodev,relatime)
```

One solution would be to not bind anything. However it will rely on the cluster Singularity configuration, which is not ideal. 

Another solution would be to only bind the process directory (in this case `62b2095ae0370ed92af3a543`). This will allow access to the output from the jobs within the same process, in the same machine.

In the solution here, I implement the binding change. It is now working on my resource.